### PR TITLE
Adding support for the missing href attribute

### DIFF
--- a/src/org/angularjs/AngularJSCustomAttributeDescriptorsProvider.java
+++ b/src/org/angularjs/AngularJSCustomAttributeDescriptorsProvider.java
@@ -57,6 +57,7 @@ public class AngularJSCustomAttributeDescriptorsProvider implements XmlAttribute
                 "controller",
                 "form",
                 "hide",
+                "href",
                 "include",
                 "init",
                 "non-bindable",


### PR DESCRIPTION
Hi John! Just realized that there is a missing href attribute in the supported attributes list so I thought that I will send a quick PR. Would be great if you could merge it (or just add support for this attribute).

BTW: Huge THANK YOU for creating this plugin!
